### PR TITLE
Bugfix 1: Awkward Button Alignment

### DIFF
--- a/src/components/recipes/RecipePanel.tsx
+++ b/src/components/recipes/RecipePanel.tsx
@@ -19,8 +19,8 @@ const RecipesPanel = ({recipes, isActive, onStatusChange}: Props) => {
     return (
         <ul role="list" className={gridClass()}>
             {recipes.sort().map((recipe: Recipe) => (
-                <li key={recipe.name} className="col-span-1 divide-y divide-gray-200 rounded-lg bg-white shadow">
-                    <div className="flex w-full items-center justify-between space-x-6 p-6">
+                <li key={recipe.name} className="col-span-1 flex flex-col justify-end divide-y divide-gray-200 rounded-lg bg-white shadow">
+                    <div className="flex w-full h-full items-center justify-between space-x-6 p-6">
                         <div className="flex-1">
                             <div className="flex items-center space-x-3">
                                 <h3 className="text-lg font-bold text-gray-900">{recipe.name}</h3>


### PR DESCRIPTION
Resolves #1

## **Context:**

- The recipe cards in any given row of the recipe panel will align their heights to be equal to the card with the most content / greatest height (in that specific row).
  - The button segment of the card fills the remaining space (as opposed to the text/content segment), which produces awkward misalignment among the buttons when one card in the row has more text content than the others.<br/>
    <img width="606" alt="image" src="https://github.com/jessfeliciano/SmartPrep/assets/53627049/eb9a9b19-500d-4c4f-8e3a-7cad3ef04ffc">


<br/>

## **Changes (Functional):**

- The button segment of the recipe cards now maintain a constant height, and the text/content segment fills any remaining space in the card.<br/>
  <img width="602" alt="image" src="https://github.com/jessfeliciano/SmartPrep/assets/53627049/94c4d658-8df8-4639-ac74-897a8bd38caa">


<br>

## **Code Changes:**

- Add flex styling to the recipe card container (the looped `li` in _RecipePanel.tsx_).
  - Pushes the button segment to the bottom of the recipe card.
- Add max-height styling to text/content segment.
  - Centers the text/content in the remaining portion of the recipe card.

<br>